### PR TITLE
Fixed flaky test-case in the following class: ConsumerJsonRecordTest.should_serialize_a_record_with_headers

### DIFF
--- a/core/src/test/java/org/jsmart/zerocode/core/kafka/receive/message/ConsumerJsonRecordTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/kafka/receive/message/ConsumerJsonRecordTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -49,7 +50,7 @@ public class ConsumerJsonRecordTest {
         // given
         JsonNode key = objectMapper.readTree("123");
         JsonNode value = objectMapper.readTree("\"val\"");
-        Map<String, String> headers = new HashMap<>();
+        Map<String, String> headers = new LinkedHashMap<>();
         headers.put("hKey", "hValue");
         headers.put("hKeyWithNullValue", null);
         ConsumerJsonRecord record = new ConsumerJsonRecord(key, value, headers);

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,15 @@
 			</dependency>
         </dependencies>
     </dependencyManagement>
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>edu.illinois</groupId>
+                <artifactId>nondex-maven-plugin</artifactId>
+                <version>2.1.7</version>
+            </plugin>
+        </plugins>
+    </build>
     <!-- Uncomment this for uber jar -->
     <!--<build>
         <plugins>


### PR DESCRIPTION
POINT OF FAILURE -> random attribute ordering in hashmap Fixed using NonDex, plugin added in parent pom.
Suggested command to check flaky tests :
> mvn nondex:nondex

For particular test:
>mvn -pl ./core nondex:nondex -Dtest=org.jsmart.zerocode.core.kafka.receive.message.ConsumerJsonRecordTest#should_serialize_a_record_with_headers

For more information: https://github.com/TestingResearchIllinois/NonDex