### PR TITLE
Fixed flaky test-case: ConsumerJsonRecordTest.should_serialize_a_record_with_headers

### DIFF
--- a/core/src/test/java/org/jsmart/zerocode/core/kafka/receive/message/ConsumerJsonRecordTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/kafka/receive/message/ConsumerJsonRecordTest.java
@@ -4,12 +4,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matcher;
 import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -49,7 +48,7 @@ public class ConsumerJsonRecordTest {
         // given
         JsonNode key = objectMapper.readTree("123");
         JsonNode value = objectMapper.readTree("\"val\"");
-        Map<String, String> headers = new HashMap<>();
+        Map<String, String> headers = new LinkedHashMap<>();
         headers.put("hKey", "hValue");
         headers.put("hKeyWithNullValue", null);
         ConsumerJsonRecord record = new ConsumerJsonRecord(key, value, headers);

--- a/core/src/test/java/org/jsmart/zerocode/core/kafka/receive/message/ConsumerJsonRecordTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/kafka/receive/message/ConsumerJsonRecordTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matcher;
 import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
 import org.junit.Test;
 

--- a/pom.xml
+++ b/pom.xml
@@ -376,11 +376,6 @@
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>${maven-dependency-plugin.version}</version>
                 </plugin>
-                <plugin> <!-- for flaky testing -->
-                    <groupId>edu.illinois</groupId>
-                    <artifactId>nondex-maven-plugin</artifactId>
-                    <version>2.1.7</version>
-                </plugin>
             </plugins>
         </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -376,6 +376,11 @@
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>${maven-dependency-plugin.version}</version>
                 </plugin>
+                <plugin> <!-- for flaky testing -->
+                    <groupId>edu.illinois</groupId>
+                    <artifactId>nondex-maven-plugin</artifactId>
+                    <version>2.1.7</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
POINT OF FAILURE -> random attribute ordering in hashmap
Fixed using NonDex pugin
Suggested command to check flaky tests :
> mvn nondex:nondex

For particular test:
Add the following lines to your pom.xml
```
  <plugin> <!-- for flaky testing -->
      <groupId>edu.illinois</groupId>
      <artifactId>nondex-maven-plugin</artifactId>
      <version>2.1.7</version>
  </plugin>
```
and run
>mvn -pl ./core nondex:nondex -Dtest=org.jsmart.zerocode.core.kafka.receive.message.ConsumerJsonRecordTest#should_serialize_a_record_with_headers -DnondexRuns=10

**OR**

>mvn -pl ./core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.jsmart.zerocode.core.kafka.receive.message.ConsumerJsonRecordTest#should_serialize_a_record_with_headers -DnondexRuns=10

For more information : https://github.com/TestingResearchIllinois/NonDex